### PR TITLE
Document that document_id also supports `%{foo}`

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -60,6 +60,8 @@ module LogStash; module Outputs; class ElasticSearch
 
       # The document ID for the index. Useful for overwriting existing entries in
       # Elasticsearch with the same ID.
+      # This can be dynamic using the `%{foo}` syntax so you can use the value of
+      # another field as an ID.
       mod.config :document_id, :validate => :string
 
       # A routing override to be applied to all processed events.


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
